### PR TITLE
Initialise modules asynchronously

### DIFF
--- a/ModuleThreadHandler.py
+++ b/ModuleThreadHandler.py
@@ -1,0 +1,114 @@
+from threading import Thread
+from queue import Queue
+import time
+
+class ThreadTask:
+  INIT = 'Initialise'
+  RUN = 'Run the module'
+
+class ModuleThreadHandler:
+  MAX_MODULE_THREADS = 3
+
+  def __init__(self, logger):
+    self.logger = logger
+
+    self.queues = []
+    self.modules_in_use = []
+    self.threads = [None for _ in range(self.MAX_MODULE_THREADS)]
+
+    self.thread_filler = None
+
+    self.closing = False
+  
+  def close(self):
+    self.closing = True
+  
+  def new_thread_slot(self):
+    try:
+      return self.threads.index(None)
+    except ValueError:
+      return None
+
+  def add_task(self, module, task, priority=0):
+    queue = Queue()
+    if task == ThreadTask.RUN and module.module is None:
+      queue.put((module, ThreadTask.INIT))
+    queue.put((module, task))
+    self.queues.append((queue, priority, module))
+    self.queues.sort(key=lambda q: -q[1])
+    self.start_thread_filler()
+
+  def start_thread_filler(self):
+    if self.closing or self.thread_filler != None or len(self.queues) == 0: return
+    self.logger.info('Starting up module thread filler...')
+    self.thread_filler = Thread(target=self.fill_threads, name='Module-Thread-Filler')
+    self.thread_filler.start()
+
+  def fill_threads(self):
+    while len(self.queues) > 0 and not self.closing:
+      queue, queue_index = self.get_queue()
+      if queue is None:
+        time.sleep(0.5)
+        continue
+      
+      if queue.empty():
+        self.queues.pop(queue_index)
+        continue
+
+      index = self.new_thread_slot()
+      if index is None:
+        time.sleep(0.5)
+        continue
+
+      module, task = queue.get()
+      if self.is_task_invalid(module, task):
+        continue
+
+      self.start_thread(module, task, index)
+      self.modules_in_use.append(module)
+    
+    self.logger.info(f"{'' if self.closing else 'Module queue is empty. '}Stopping module thread filler...")
+    self.thread_filler = None
+  
+  def get_queue(self):
+    for i, (queue, _, module) in enumerate(self.queues):
+      if module not in self.modules_in_use:
+        return queue, i
+    return None, None
+
+  def start_thread(self, module, task, index):
+    task_switcher = {
+      ThreadTask.INIT: 'Initialising',
+      ThreadTask.RUN: 'Running'
+    }
+
+    def wrapper():
+      self.logger.info(f'{task_switcher[task]} module: `{module.name}`')
+      self.get_func_from_task(module, task)()
+      self.threads[index] = None
+      self.modules_in_use.remove(module)
+
+    name = self.get_thread_name(module, task)
+    self.logger.info(f'Starting thread: {name}')
+    self.threads[index] = Thread(target=wrapper, name=name)
+    self.threads[index].start()
+  
+  @staticmethod
+  def is_task_invalid(module, task):
+    return module.module is not None and task == ThreadTask.INIT
+  
+  @staticmethod
+  def get_func_from_task(module, task):
+    task_switcher = {
+      ThreadTask.INIT: module.initialise,
+      ThreadTask.RUN: module.run
+    }
+    return task_switcher[task]
+
+  @staticmethod
+  def get_thread_name(module, task):
+    task_switcher = {
+      ThreadTask.INIT: 'init',
+      ThreadTask.RUN: 'run'
+    }
+    return f'Module-Thread ({module.name})[{task_switcher[task]}]'


### PR DESCRIPTION
The PR should let all **modules initialise asynchronously** from the main program, therefore avoiding unwanted blocks or errors in the main loop.

There were many considerations that went into how to set up the infrastructure to handle the threads.
- All modules need to be initialised at the start of the server
- Modules cannot run before they are initialised
- In the future, there should be a possibility for restarting/turning off modules (Undoing the initialisation)
- The max number of threads should not be exceeded
- Waiting for threads to complete / threads to be ready to run should not block the main loop
- Modules should not initialise more than once
- If modules are initialising, but one needs to run, then it would be preferable to prioritise initialising that module
- Modules should not be accessed by separate threads at the same time to avoid interference
- In the future, there should be a possibility for modules to have other tasks to be done asynchronously other than just initialising or running
- The infrastructure should use the fewest number of threads possible, but mainly focus or not having threads constantly open. The threads should always be doing an action or waiting for a specific event, and then close once its purpose is complete.

The main logic for this has been moved into a separate file called *ModuleThreadHandler.py*. This object is initialised with the module logger and controls the asynchronous tasks for all modules. To start the main process in this object one would call `ModuleThreadHandler.add_task(...)`. This function takes a module, a task, and a priority. This does the following:
1. Creates a queue object of tasks to complete the goal of the provided task (This is simply the task itself in the case of running, but if an uninitialised module is asked to run, then it would need to initialise first, then run).
2. The priority value provided is recorded with the new object. The higher the priority, the sooner the tasks will be assigned a thread. This is used so that threads needing to run are prioritised over modules only wanting to initialise.
3. The module the tasks refer to is also remembered and then the information is added to the array `ModuleThreadHandler.queues`.
4. The function finally starts up (if not already running) the thread-filler.

The **Module-Thread-Filler** is a separate thread very similar to the backlog thread of the ModuleHandler, which has since been taking out. It runs a loop as long as there are queues with tasks to complete and handles finding the tasks which are supposed to be done first and most importantly **can** be done first, and then allocates threads to these tasks. It runs on a loop following these general steps:
1. The queue object with the highest priority referring to a module that is not in use is found. If all queues are in use, then the thread will sleep for half a second and then restart the loop.
2. It will check if the queue object has more tasks to complete. If there are no tasks the queue is deleted.
3. It will then check if it can make a new thread or if it would exceed the maximum number of threads. If all threads are in use then the thread will sleep for half a second and then restart the loop.
4. It will then get the first task from the queue and check that it is valid. At the moment, the only invalid tasks are those where an already initialised module tries to be initialised again. If it is invalid, the task is skipped.
5. The module and task are sent off to the function `ModuleThreadHandler.start_thread(...)` where a thread is created for the task.

Once all queues are empty then the module-thread-filler is closed and only started again once a new task is scheduled.